### PR TITLE
use default priority if one is not specified

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -2295,6 +2295,10 @@ bool simple_wallet::transfer_main(int transfer_type, const std::vector<std::stri
       local_args.erase(local_args.begin());
       priority = std::distance(allowed_priority_strings.begin(), priority_pos);
     }
+    else
+    {
+      priority = m_wallet->get_default_priority();
+    }
   }
 
   const size_t min_args = (transfer_type == TransferLocked) ? 3 : 2;


### PR DESCRIPTION
This fixes a bug where the lowest priority would be used if a priority string ("defualt", "low", etc) is not passed as an arg in `transfer`. If a priority is not set in the `transfer` command, then we can use the priority specified in `set priority`.