### PR TITLE
CLI: exit if specified wallet file does not exist

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -1603,6 +1603,16 @@ bool simple_wallet::open_wallet(const boost::program_options::variables_map& vm)
     fail_msg_writer() << tr("wallet file path not valid: ") << m_wallet_file;
     return false;
   }
+  bool keys_file_exists;
+  bool wallet_file_exists;
+
+  tools::wallet2::wallet_exists(m_wallet_file, keys_file_exists, wallet_file_exists);
+  if(!keys_file_exists)
+  {
+    fail_msg_writer() << boost::format(tr("failed to load wallet %s does not exist ")) % m_wallet_file;
+    return false;
+  }
+
   std::string password;
   try
   {


### PR DESCRIPTION
Exit immediatly if wallet file does not exist when `--wallet-file` flag is used