### PR TITLE
blackball: move default shared-ringdb inside .masari

### DIFF
--- a/src/blockchain_utilities/blockchain_blackball.cpp
+++ b/src/blockchain_utilities/blockchain_blackball.cpp
@@ -69,9 +69,8 @@ namespace std
 static std::string get_default_db_path()
 {
   boost::filesystem::path dir = tools::get_default_data_dir();
-  // remove .bitmonero, replace with .shared-ringdb
-  dir = dir.remove_filename();
-  dir /= ".shared-ringdb";
+  // store in .masari/shared-ringdb
+  dir /= "shared-ringdb";
   return dir.string();
 }
 


### PR DESCRIPTION
Move the default shared-ringdb folder inside the default directory in order to not conflict with upstream or forked coins. This would mean it is stored in `~/.masari/shared-ringdb` (at least on ubuntu) by default