### PR TITLE
dns_utils: bump up min log level for dns checkpoint warnings

### DIFF
--- a/src/common/dns_utils.cpp
+++ b/src/common/dns_utils.cpp
@@ -506,7 +506,7 @@ bool load_txt_records_from_dns(std::vector<std::string> &good_records, const std
 
   if (num_valid_records < 2)
   {
-    LOG_PRINT_L0("WARNING: no two valid MasariPulse DNS checkpoint records were received");
+    LOG_PRINT_L2("WARNING: no two valid MasariPulse DNS checkpoint records were received");
     return false;
   }
 
@@ -528,7 +528,7 @@ bool load_txt_records_from_dns(std::vector<std::string> &good_records, const std
 
   if (good_records_index < 0)
   {
-    LOG_PRINT_L0("WARNING: no two MasariPulse DNS checkpoint records matched");
+    LOG_PRINT_L2("WARNING: no two MasariPulse DNS checkpoint records matched");
     return false;
   }
 


### PR DESCRIPTION
This is a subjectivly advanced feature and often confuses new users. Bump up the minimum log level to display this warning to log level 2 to avoid confusion but still easily accessible for debugging