### PR TITLE
cryptonote_format_utils: explicitly use cn variant 1 for version 6

### DIFF
--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -854,7 +854,17 @@ namespace cryptonote
   bool get_block_longhash(const block& b, crypto::hash& res, uint64_t height)
   {
     blobdata bd = get_block_hashing_blob(b);
-    const int cn_variant = b.major_version >= 5 ? b.major_version - 4 : 0;
+    
+    int cn_variant;
+    if(b.major_version < 5)
+    {
+      cn_variant = 0;
+	}
+	else
+	{
+      cn_variant = 1;
+    }
+    
     crypto::cn_slow_hash(bd.data(), bd.size(), res, cn_variant);
     return true;
   }


### PR DESCRIPTION
When we fork to v6 cn_variant would be 6 - 4 = 2  even though we want to use variant 1.
cn_slow_hash technically only checks `if(variant > 0)` and then uses variant 1, but it is better to explicitly set cn_variant to 1 for v5 and v6, especially if we want to use a new variant (which would be variant 2) in the future.