### PR TITLE
command_parser_executor: handle user input for optional miner params better

### DIFF
--- a/src/daemon/command_parser_executor.cpp
+++ b/src/daemon/command_parser_executor.cpp
@@ -27,6 +27,7 @@
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "common/dns_utils.h"
+#include "common/command_line.h"
 #include "daemon/command_parser_executor.h"
 
 #undef MONERO_DEFAULT_LOG_CATEGORY
@@ -325,12 +326,26 @@ bool t_command_parser_executor::start_mining(const std::vector<std::string>& arg
   
   if(args.size() == 4)
   {
-    ignore_battery = args[3] == "true";
+    if(args[3] == "true" || command_line::is_yes(args[3]) || args[3] == "1")
+    {
+      ignore_battery = true;
+    }
+    else if(args[3] != "false" && !command_line::is_no(args[3]) && args[3] != "0")
+    {
+      return false;
+    }
   }  
   
   if(args.size() >= 3)
   {
-    do_background_mining = args[2] == "true";
+    if(args[2] == "true" || command_line::is_yes(args[2]) || args[2] == "1")
+    {
+      do_background_mining = true;
+    }
+    else if(args[2] != "false" && !command_line::is_no(args[2]) && args[2] != "0")
+    {
+      return false;
+    }
   }
   
   if(args.size() >= 2)


### PR DESCRIPTION
Don't just check for "true" or "false" strings, allow 0/1, true/false, yes/no, y/n