### PR TITLE
simplewallet: update log categories message

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -2408,7 +2408,7 @@ bool simple_wallet::set_log(const std::vector<std::string> &args)
     }
   }
   
-  success_msg_writer() << "New log categories: " << mlog_get_categories();
+  success_msg_writer() << "Log categories in use: " << mlog_get_categories();
   return true;
 }
 //----------------------------------------------------------------------------------------------------


### PR DESCRIPTION
All of the log categories in use are shown (as they should be) instead of only the new ones being used so the message should reflect that.