### PR TITLE
wallet api: add isMultisig function

### DIFF
--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -701,6 +701,17 @@ int WalletImpl::status() const
     return m_status;
 }
 
+bool WalletImpl::isMultisig() const
+{
+  bool ready;
+  if(!m_wallet->multisig(&ready))
+    return false;
+  else if(!ready)
+    return false;
+  else
+    return true;
+}
+
 std::string WalletImpl::errorString() const
 {
     return m_errorString;

--- a/src/wallet/api/wallet.h
+++ b/src/wallet/api/wallet.h
@@ -83,6 +83,7 @@ public:
     void setSeedLanguage(const std::string &arg);
     // void setListener(Listener *) {}
     int status() const;
+    bool isMultisig() const;
     std::string errorString() const;
     bool setPassword(const std::string &password);
     std::string address(uint32_t accountIndex = 0, uint32_t addressIndex = 0) const;

--- a/src/wallet/api/wallet2_api.h
+++ b/src/wallet/api/wallet2_api.h
@@ -115,6 +115,7 @@ struct UnsignedTransaction
 
     virtual ~UnsignedTransaction() = 0;
     virtual int status() const = 0;
+    virtual bool isMultisig() const = 0;
     virtual std::string errorString() const = 0;
     virtual std::vector<uint64_t> amount() const = 0;
     virtual std::vector<uint64_t>  fee() const = 0;


### PR DESCRIPTION
The GUI wallet currently doesn't support multisig wallets and most wallets in general don't support multisig so they should be able to tell if a wallet opened is a multisig wallet.