### PR TITLE
uncle-mining: Initial uncle mining structure

### DIFF
--- a/src/cryptonote_basic/cryptonote_basic.h
+++ b/src/cryptonote_basic/cryptonote_basic.h
@@ -330,6 +330,36 @@ namespace cryptonote
     END_SERIALIZE()
   };
 
+  struct uncle_block: public block_header
+  {
+  private:
+    // hash cash
+    mutable std::atomic<bool> hash_valid;
+
+  public:
+    uncle_block(): block_header(), hash_valid(false) {}
+    uncle_block(const uncle_block &b): block_header(b), hash_valid(false), miner_tx_hash(b.miner_tx_hash), tx_hashes(b.tx_hashes) { if (b.is_hash_valid()) { hash = b.hash; set_hash_valid(true); } }
+    uncle_block &operator=(const uncle_block &b) { block_header::operator=(b); hash_valid = false; miner_tx_hash = b.miner_tx_hash; tx_hashes = b.tx_hashes; if (b.is_hash_valid()) { hash = b.hash; set_hash_valid(true); } return *this; }
+    void invalidate_hashes() { set_hash_valid(false); }
+    bool is_hash_valid() const { return hash_valid.load(std::memory_order_acquire); }
+    void set_hash_valid(bool v) const { hash_valid.store(v,std::memory_order_release); }
+
+    crypto::hash miner_tx_hash;
+    std::vector<crypto::hash> tx_hashes;
+
+    // hash cash
+    mutable crypto::hash hash;
+
+    BEGIN_SERIALIZE_OBJECT()
+      if (!typename Archive<W>::is_saving())
+        set_hash_valid(false);
+
+      FIELDS(*static_cast<block_header *>(this))
+      FIELD(miner_tx_hash)
+      FIELD(tx_hashes)
+    END_SERIALIZE()
+  };
+
   struct block: public block_header
   {
   private:
@@ -338,14 +368,15 @@ namespace cryptonote
 
   public:
     block(): block_header(), hash_valid(false) {}
-    block(const block &b): block_header(b), hash_valid(false), miner_tx(b.miner_tx), tx_hashes(b.tx_hashes) { if (b.is_hash_valid()) { hash = b.hash; set_hash_valid(true); } }
-    block &operator=(const block &b) { block_header::operator=(b); hash_valid = false; miner_tx = b.miner_tx; tx_hashes = b.tx_hashes; if (b.is_hash_valid()) { hash = b.hash; set_hash_valid(true); } return *this; }
+    block(const block &b): block_header(b), hash_valid(false), miner_tx(b.miner_tx), tx_hashes(b.tx_hashes), uncle(b.uncle) { if (b.is_hash_valid()) { hash = b.hash; set_hash_valid(true); } }
+    block &operator=(const block &b) { block_header::operator=(b); hash_valid = false; miner_tx = b.miner_tx; tx_hashes = b.tx_hashes; uncle = b.uncle; if (b.is_hash_valid()) { hash = b.hash; set_hash_valid(true); } return *this; }
     void invalidate_hashes() { set_hash_valid(false); }
     bool is_hash_valid() const { return hash_valid.load(std::memory_order_acquire); }
     void set_hash_valid(bool v) const { hash_valid.store(v,std::memory_order_release); }
 
     transaction miner_tx;
     std::vector<crypto::hash> tx_hashes;
+    uncle_block uncle;
 
     // hash cash
     mutable crypto::hash hash;
@@ -357,6 +388,7 @@ namespace cryptonote
       FIELDS(*static_cast<block_header *>(this))
       FIELD(miner_tx)
       FIELD(tx_hashes)
+      FIELD(uncle)
     END_SERIALIZE()
   };
 

--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -883,12 +883,23 @@ namespace cryptonote
     return true;
   }
   //---------------------------------------------------------------
-  bool hash_block_hashing_blob(blobdata blob, crypto::hash& res, int cn_variant)
+  crypto::hash get_uncle_block_long_hash(block b, uint8_t hf_version)
   {
-    if(cn_variant < 0 || cn_variant > 2)
-      return false;
+    int cn_variant;
+    if(hf_version < 5) {
+      cn_variant = 0;
+    }
+    else if (hf_version < 7) {
+      cn_variant = 1;
+    }
+    else {
+      cn_variant = 2;
+    }
+    
+    crypto::hash res = null_hash;
+    blobdata blob = get_uncle_block_old_hashing_blob(b);
     crypto::cn_slow_hash(blob.data(), blob.size(), res, cn_variant);
-    return true;
+    return res;
   }
   //---------------------------------------------------------------
   std::vector<uint64_t> relative_output_offsets_to_absolute(const std::vector<uint64_t>& off)

--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -883,13 +883,13 @@ namespace cryptonote
     return true;
   }
   //---------------------------------------------------------------
-  crypto::hash get_uncle_block_long_hash(block b, uint8_t hf_version)
+  crypto::hash get_uncle_block_long_hash(block b)
   {
     int cn_variant;
-    if(hf_version < 5) {
+    if(b.major_version < 5) {
       cn_variant = 0;
     }
-    else if (hf_version < 7) {
+    else if (b.major_version < 7) {
       cn_variant = 1;
     }
     else {

--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -818,6 +818,19 @@ namespace cryptonote
     return blob;
   }
   //---------------------------------------------------------------
+  blobdata get_uncle_block_old_hashing_blob(const block& b)
+  {
+    blobdata blob = t_serializable_object_to_blob(static_cast<block_header>(b));
+    std::vector<crypto::hash> tx_hashes;
+    tx_hashes.push_back(b.uncle.miner_tx_hash);
+    for(auto& th : b.uncle.tx_hashes)
+      tx_hashes.push_back(th);
+    crypto::hash tree_root_hash = get_tx_tree_hash(tx_hashes);
+    blob.append(reinterpret_cast<const char*>(&tree_root_hash), sizeof(tree_root_hash));
+    blob.append(tools::get_varint_data(b.uncle.tx_hashes.size()+1));
+    return blob;
+  }
+  //---------------------------------------------------------------
   bool calculate_block_hash(const block& b, crypto::hash& res)
   {
     bool hash_result = get_object_hash(get_block_hashing_blob(b), res);
@@ -867,6 +880,14 @@ namespace cryptonote
     }
     
     crypto::cn_slow_hash(bd.data(), bd.size(), res, cn_variant);
+    return true;
+  }
+  //---------------------------------------------------------------
+  bool hash_block_hashing_blob(blobdata blob, crypto::hash& res, int cn_variant)
+  {
+    if(cn_variant < 0 || cn_variant > 2)
+      return false;
+    crypto::cn_slow_hash(blob.data(), blob.size(), res, cn_variant);
     return true;
   }
   //---------------------------------------------------------------

--- a/src/cryptonote_basic/cryptonote_format_utils.h
+++ b/src/cryptonote_basic/cryptonote_format_utils.h
@@ -107,8 +107,8 @@ namespace cryptonote
   bool get_block_hash(const block& b, crypto::hash& res);
   crypto::hash get_block_hash(const block& b);
   bool get_block_longhash(const block& b, crypto::hash& res, uint64_t height);
-  bool hash_block_hashing_blob(blobdata blob, crypto::hash& res, int cn_variant);
   crypto::hash get_block_longhash(const block& b, uint64_t height);
+  crypto::hash get_uncle_block_long_hash(block b, uint8_t hf_version);
   bool parse_and_validate_block_from_blob(const blobdata& b_blob, block& b);
   bool get_inputs_money_amount(const transaction& tx, uint64_t& money);
   uint64_t get_outs_money_amount(const transaction& tx);

--- a/src/cryptonote_basic/cryptonote_format_utils.h
+++ b/src/cryptonote_basic/cryptonote_format_utils.h
@@ -108,7 +108,7 @@ namespace cryptonote
   crypto::hash get_block_hash(const block& b);
   bool get_block_longhash(const block& b, crypto::hash& res, uint64_t height);
   crypto::hash get_block_longhash(const block& b, uint64_t height);
-  crypto::hash get_uncle_block_long_hash(block b, uint8_t hf_version);
+  crypto::hash get_uncle_block_long_hash(block b);
   bool parse_and_validate_block_from_blob(const blobdata& b_blob, block& b);
   bool get_inputs_money_amount(const transaction& tx, uint64_t& money);
   uint64_t get_outs_money_amount(const transaction& tx);

--- a/src/cryptonote_basic/cryptonote_format_utils.h
+++ b/src/cryptonote_basic/cryptonote_format_utils.h
@@ -102,10 +102,12 @@ namespace cryptonote
   bool get_transaction_hash(const transaction& t, crypto::hash& res, size_t* blob_size);
   bool calculate_transaction_hash(const transaction& t, crypto::hash& res, size_t* blob_size);
   blobdata get_block_hashing_blob(const block& b);
+  blobdata get_uncle_block_old_hashing_blob(const block& b);
   bool calculate_block_hash(const block& b, crypto::hash& res);
   bool get_block_hash(const block& b, crypto::hash& res);
   crypto::hash get_block_hash(const block& b);
   bool get_block_longhash(const block& b, crypto::hash& res, uint64_t height);
+  bool hash_block_hashing_blob(blobdata blob, crypto::hash& res, int cn_variant);
   crypto::hash get_block_longhash(const block& b, uint64_t height);
   bool parse_and_validate_block_from_blob(const blobdata& b_blob, block& b);
   bool get_inputs_money_amount(const transaction& tx, uint64_t& money);

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -3205,6 +3205,26 @@ leave:
     bvc.m_verifivation_failed = true;
     goto leave;
   }
+  
+  // do some basic validation on the uncle block
+  if (bl.uncle.major_version != 0 || bl.uncle.minor_version != 0 || bl.uncle.timestamp != 0 || bl.uncle.prev_id != null_hash || bl.uncle.nonce != 0 || bl.uncle.miner_tx_hash != null_hash)
+  {
+    if (bl.uncle.minor_version != m_hardfork->get_current_version())
+    {
+      MERROR_VER("Block with id: " << id << std::endl << "has invalid uncle block minor version: " << bl.uncle.minor_version);
+      bvc.m_verifivation_failed = true;
+      goto leave;
+    }
+    // check that the uncle block is on top of the second to last block in the main chain
+    block previous_block = m_db->get_block_from_height(m_db->height() - 2);
+    crypto::hash previous_block_hash = get_block_hash(previous_block);
+    if (previous_block_hash != bl.uncle.prev_id)
+    {
+      MERROR_VER("Block with id: " << id << std::endl << "has uncle block with invalid previous hash: " << bl.uncle.prev_id << " Expected: " << previous_block_hash);
+      bvc.m_verifivation_failed = true;
+      goto leave;
+    }
+  }
 
   TIME_MEASURE_FINISH(t1);
   TIME_MEASURE_START(t2);

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -1201,12 +1201,6 @@ bool Blockchain::create_block_template(block& b, std::string miner_address, diff
            LOG_ERROR("Failed to add alternative block as top block");
          
          m_uncle_blocks.push_back(old_top);
-         b.uncle.major_version = b.major_version;
-         b.uncle.minor_version = b.minor_version;
-         b.uncle.timestamp = old_top.timestamp;
-         b.uncle.prev_id = old_top.prev_id;
-         b.uncle.nonce = old_top.nonce;
-         b.uncle.miner_tx_hash = get_transaction_hash(old_top.miner_tx);
          LOG_PRINT_L3("Reoganization for uncle block success");
       }
       // if top block has lowest hash then the alternative block is the uncle
@@ -1219,7 +1213,9 @@ bool Blockchain::create_block_template(block& b, std::string miner_address, diff
         b.uncle.nonce = last_alt_block.nonce;
         b.uncle.miner_tx_hash = get_transaction_hash(last_alt_block.miner_tx);
       }
-      else if(m_uncle_blocks.size() > 0)
+      else
+        b.uncle.miner_tx_hash = null_hash;
+      if(m_uncle_blocks.size() > 0)
       {
         block uncle_b = m_uncle_blocks.back();
         crypto::hash uncle_block_hash = get_block_hash(uncle_b);
@@ -1233,11 +1229,7 @@ bool Blockchain::create_block_template(block& b, std::string miner_address, diff
           b.uncle.nonce = uncle_b.nonce;
           b.uncle.miner_tx_hash = get_transaction_hash(uncle_b.miner_tx);
         }
-        else
-          b.uncle.miner_tx_hash = null_hash;
       }
-      else
-        b.uncle.miner_tx_hash = null_hash;
     }
     else
       b.uncle.miner_tx_hash = null_hash;

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -284,7 +284,7 @@ namespace cryptonote
      *
      * @return the target
      */
-    difficulty_type get_difficulty_for_next_block();
+    difficulty_type get_difficulty_for_next_block(bool uncle = false);
 
     /**
      * @brief adds a block to the blockchain

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -1016,6 +1016,8 @@ namespace cryptonote
     // some invalid blocks
     blocks_ext_by_hash m_invalid_blocks;     // crypto::hash -> block_extended_info
 
+    std::vector<block> m_uncle_blocks;
+
 
     checkpoints m_checkpoints;
     bool m_enforce_dns_checkpoints;
@@ -1391,3 +1393,4 @@ namespace cryptonote
     bool expand_transaction_2(transaction &tx, const crypto::hash &tx_prefix_hash, const std::vector<std::vector<rct::ctkey>> &pubkeys);
   };
 }  // namespace cryptonote
+

--- a/src/cryptonote_core/cryptonote_tx_utils.cpp
+++ b/src/cryptonote_core/cryptonote_tx_utils.cpp
@@ -587,6 +587,7 @@ namespace cryptonote
     bl.nonce = config::GENESIS_NONCE;
     miner::find_nonce_for_given_block(bl, 1, 0);
     bl.invalidate_hashes();
+    bl.uncle.miner_tx_hash = null_hash;
     return true;
   }
   //---------------------------------------------------------------


### PR DESCRIPTION
Not suitable for mainnet. Restructures blocks to allow uncles blocks, include uncle blocks in block template when appropriate, miners automatically switch to the chain with the lowest top block hash, basic validation tests on uncles before getting added to the blockchain