### PR TITLE
RingCT: bulletproofs tweaks

### DIFF
--- a/src/crypto/crypto-ops.c
+++ b/src/crypto/crypto-ops.c
@@ -3709,7 +3709,7 @@ void sc_muladd(unsigned char *s, const unsigned char *a, const unsigned char *b,
 
 /* Assumes that a != INT64_MIN */
 static int64_t signum(int64_t a) {
-  return (a >> 63) - ((-a) >> 63);
+  return a > 0 ? 1 : a < 0 ? -1 : 0;
 }
 
 int sc_check(const unsigned char *s) {

--- a/src/ringct/rctOps.cpp
+++ b/src/ringct/rctOps.cpp
@@ -59,6 +59,17 @@ namespace rct {
 
 
     //Various key generation functions
+    
+    bool toPointCheckOrder(ge_p3 *P, const unsigned char *data)
+    {
+        if (ge_frombytes_vartime(P, data))
+            return false;
+        ge_p2 R;
+        ge_scalarmult(&R, curveOrder().bytes, P);
+        key tmp;
+        ge_tobytes(tmp.bytes, &R);
+        return tmp == identity();
+    }
 
     //generates a random scalar which can be used as a secret key or mask
     void skGen(key &sk) {
@@ -205,6 +216,13 @@ namespace rct {
         key aP;
         ge_tobytes(aP.bytes, &R);
         return aP;
+    }
+    
+
+    //Computes aL where L is the curve order
+    bool isInMainSubgroup(const key & a) {
+        ge_p3 p3;
+        return toPointCheckOrder(&p3, a.bytes);
     }
 
     //Curve addition / subtractions

--- a/src/ringct/rctOps.h
+++ b/src/ringct/rctOps.h
@@ -82,6 +82,8 @@ namespace rct {
     keyM keyMInit(size_t rows, size_t cols);
 
     //Various key generation functions        
+    
+    bool toPointCheckOrder(ge_p3 *P, const unsigned char *data);
 
     //generates a random scalar which can be used as a secret key or mask
     key skGen();
@@ -118,6 +120,8 @@ namespace rct {
     key scalarmultKey(const key &P, const key &a);
     //Computes aH where H= toPoint(cn_fast_hash(G)), G the basepoint
     key scalarmultH(const key & a);
+    // checks a is in the main subgroup (ie, not a small one)
+    bool isInMainSubgroup(const key & a);
 
     //Curve addition / subtractions
 


### PR DESCRIPTION
Check that input scalars are less than `l`, fix signum, reject points that aren't in the main subgroup.

Thanks to moneromooo and Kudelski Labs