### PR TITLE
core rpc: add get_transactions_by_height rpc call

### DIFF
--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -691,11 +691,11 @@ namespace cryptonote
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------
-  bool core_rpc_server::on_get_transactions_by_height(const COMMAND_RPC_GET_TRANSACTIONS_BY_HEIGHT::request& req, COMMAND_RPC_GET_TRANSACTIONS_BY_HEIGHT::response& res)
+  bool core_rpc_server::on_get_transactions_by_heights(const COMMAND_RPC_GET_TRANSACTIONS_BY_HEIGHT::request& req, COMMAND_RPC_GET_TRANSACTIONS_BY_HEIGHT::response& res)
   {
     PERF_TIMER(on_get_transactions_by_height);
     bool ok;
-    if (use_bootstrap_daemon_if_necessary<COMMAND_RPC_GET_TRANSACTIONS_BY_HEIGHT>(invoke_http_mode::JON, "/gettransactions_by_height", req, res, ok))
+    if (use_bootstrap_daemon_if_necessary<COMMAND_RPC_GET_TRANSACTIONS_BY_HEIGHT>(invoke_http_mode::JON, "/gettransactions_by_heights", req, res, ok))
       return ok;
 
     std::vector<crypto::hash> vh;

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -700,13 +700,16 @@ namespace cryptonote
 
     std::vector<crypto::hash> vh;
     
-    block blk;
-    bool orphan = false;
-    crypto::hash block_hash = m_core.get_block_id_by_height(req.height);
-    bool have_block = m_core.get_block_by_hash(block_hash, blk, &orphan);
+    for (size_t i = 0; i < req.heights.size(); i++)
+    {
+      block blk;
+      bool orphan = false;
+      crypto::hash block_hash = m_core.get_block_id_by_height(req.heights[i]);
+      bool have_block = m_core.get_block_by_hash(block_hash, blk, &orphan);
     
-    for(auto& btxs: blk.tx_hashes)
-      vh.push_back(btxs);
+      for(auto& btxs: blk.tx_hashes)
+        vh.push_back(btxs);
+    }
     
     std::list<crypto::hash> missed_txs;
     std::list<transaction> txs;

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -691,6 +691,159 @@ namespace cryptonote
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------
+  bool core_rpc_server::on_get_transactions_by_height(const COMMAND_RPC_GET_TRANSACTIONS_BY_HEIGHT::request& req, COMMAND_RPC_GET_TRANSACTIONS_BY_HEIGHT::response& res)
+  {
+    PERF_TIMER(on_get_transactions_by_height);
+    bool ok;
+    if (use_bootstrap_daemon_if_necessary<COMMAND_RPC_GET_TRANSACTIONS_BY_HEIGHT>(invoke_http_mode::JON, "/gettransactions_by_height", req, res, ok))
+      return ok;
+
+    std::vector<crypto::hash> vh;
+    
+    block blk;
+    bool orphan = false;
+    crypto::hash block_hash = m_core.get_block_id_by_height(req.height);
+    bool have_block = m_core.get_block_by_hash(block_hash, blk, &orphan);
+    
+    for(auto& btxs: blk.tx_hashes)
+      vh.push_back(btxs);
+    
+    std::list<crypto::hash> missed_txs;
+    std::list<transaction> txs;
+    bool r = m_core.get_transactions(vh, txs, missed_txs);
+    
+    std::list<std::string> tx_hashes;
+    for(auto& tx: txs)
+      tx_hashes.push_back(string_tools::pod_to_hex(get_transaction_hash(tx)));
+    
+    if(!r)
+    {
+      res.status = "Failed";
+      return true;
+    }
+    LOG_PRINT_L2("Found " << txs.size() << "/" << vh.size() << " transactions on the blockchain");
+
+    // try the pool for any missing txes
+    size_t found_in_pool = 0;
+    std::unordered_set<crypto::hash> pool_tx_hashes;
+    std::unordered_map<crypto::hash, bool> double_spend_seen;
+    if (!missed_txs.empty())
+    {
+      std::vector<tx_info> pool_tx_info;
+      std::vector<spent_key_image_info> pool_key_image_info;
+      bool r = m_core.get_pool_transactions_and_spent_keys_info(pool_tx_info, pool_key_image_info);
+      if(r)
+      {
+        // sort to match original request
+        std::list<transaction> sorted_txs;
+        std::vector<tx_info>::const_iterator i;
+        for (const crypto::hash &h: vh)
+        {
+          if (std::find(missed_txs.begin(), missed_txs.end(), h) == missed_txs.end())
+          {
+            if (txs.empty())
+            {
+              res.status = "Failed: internal error - txs is empty";
+              return true;
+            }
+            // core returns the ones it finds in the right order
+            if (get_transaction_hash(txs.front()) != h)
+            {
+              res.status = "Failed: tx hash mismatch";
+              return true;
+            }
+            sorted_txs.push_back(std::move(txs.front()));
+            txs.pop_front();
+          }
+          else if ((i = std::find_if(pool_tx_info.begin(), pool_tx_info.end(), [h](const tx_info &txi) { return epee::string_tools::pod_to_hex(h) == txi.id_hash; })) != pool_tx_info.end())
+          {
+            cryptonote::transaction tx;
+            if (!cryptonote::parse_and_validate_tx_from_blob(i->tx_blob, tx))
+            {
+              res.status = "Failed to parse and validate tx from blob";
+              return true;
+            }
+            sorted_txs.push_back(tx);
+            missed_txs.remove(h);
+            pool_tx_hashes.insert(h);
+            const std::string hash_string = epee::string_tools::pod_to_hex(h);
+            for (const auto &ti: pool_tx_info)
+            {
+              if (ti.id_hash == hash_string)
+              {
+                double_spend_seen.insert(std::make_pair(h, ti.double_spend_seen));
+                break;
+              }
+            }
+            ++found_in_pool;
+          }
+        }
+        txs = sorted_txs;
+      }
+      LOG_PRINT_L2("Found " << found_in_pool << "/" << vh.size() << " transactions in the pool");
+    }
+
+    std::list<std::string>::const_iterator txhi = tx_hashes.begin();
+    std::vector<crypto::hash>::const_iterator vhi = vh.begin();
+    for(auto& tx: txs)
+    {
+      res.txs.push_back(COMMAND_RPC_GET_TRANSACTIONS_BY_HEIGHT::entry());
+      COMMAND_RPC_GET_TRANSACTIONS_BY_HEIGHT::entry &e = res.txs.back();
+
+      crypto::hash tx_hash = *vhi++;
+      e.tx_hash = *txhi++;
+      blobdata blob = req.prune ? get_pruned_tx_blob(tx) : t_serializable_object_to_blob(tx);
+      e.as_hex = string_tools::buff_to_hex_nodelimer(blob);
+      if (req.decode_as_json)
+        e.as_json = obj_to_json_str(tx);
+      e.in_pool = pool_tx_hashes.find(tx_hash) != pool_tx_hashes.end();
+      if (e.in_pool)
+      {
+        e.block_height = e.block_timestamp = std::numeric_limits<uint64_t>::max();
+        if (double_spend_seen.find(tx_hash) != double_spend_seen.end())
+        {
+          e.double_spend_seen = double_spend_seen[tx_hash];
+        }
+        else
+        {
+          MERROR("Failed to determine double spend status for " << tx_hash);
+          e.double_spend_seen = false;
+        }
+      }
+      else
+      {
+        e.block_height = m_core.get_blockchain_storage().get_db().get_tx_block_height(tx_hash);
+        e.block_timestamp = m_core.get_blockchain_storage().get_db().get_block_timestamp(e.block_height);
+        e.double_spend_seen = false;
+      }
+
+      // fill up old style responses too, in case an old wallet asks
+      res.txs_as_hex.push_back(e.as_hex);
+      if (req.decode_as_json)
+        res.txs_as_json.push_back(e.as_json);
+
+      // output indices too if not in pool
+      if (pool_tx_hashes.find(tx_hash) == pool_tx_hashes.end())
+      {
+        bool r = m_core.get_tx_outputs_gindexs(tx_hash, e.output_indices);
+        if (!r)
+        {
+          res.status = "Failed";
+          return false;
+        }
+      }
+    }
+
+    for(const auto& miss_tx: missed_txs)
+    {
+      res.missed_tx.push_back(string_tools::pod_to_hex(miss_tx));
+    }
+
+    LOG_PRINT_L2(res.txs.size() << " transactions found, " << res.missed_tx.size() << " not found");
+    res.status = CORE_RPC_STATUS_OK;
+    return true;
+  }
+  //------------------------------------------------------------------------------------------------------------------------------
   bool core_rpc_server::on_is_key_image_spent(const COMMAND_RPC_IS_KEY_IMAGE_SPENT::request& req, COMMAND_RPC_IS_KEY_IMAGE_SPENT::response& res, bool request_has_rpc_origin)
   {
     PERF_TIMER(on_is_key_image_spent);

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -94,6 +94,7 @@ namespace cryptonote
       MAP_URI_AUTO_BIN2("/getrandom_rctouts.bin", on_get_random_rct_outs, COMMAND_RPC_GET_RANDOM_RCT_OUTPUTS)
       MAP_URI_AUTO_JON2("/get_transactions", on_get_transactions, COMMAND_RPC_GET_TRANSACTIONS)
       MAP_URI_AUTO_JON2("/gettransactions", on_get_transactions, COMMAND_RPC_GET_TRANSACTIONS)
+      MAP_URI_AUTO_JON2("/gettransactions_by_height", on_get_transactions_by_height, COMMAND_RPC_GET_TRANSACTIONS_BY_HEIGHT)
       MAP_URI_AUTO_JON2("/get_alt_blocks_hashes", on_get_alt_blocks_hashes, COMMAND_RPC_GET_ALT_BLOCKS_HASHES)
       MAP_URI_AUTO_JON2("/is_key_image_spent", on_is_key_image_spent, COMMAND_RPC_IS_KEY_IMAGE_SPENT)
       MAP_URI_AUTO_JON2("/send_raw_transaction", on_send_raw_tx, COMMAND_RPC_SEND_RAW_TX)
@@ -163,6 +164,7 @@ namespace cryptonote
     bool on_get_blocks_by_height(const COMMAND_RPC_GET_BLOCKS_BY_HEIGHT::request& req, COMMAND_RPC_GET_BLOCKS_BY_HEIGHT::response& res);
     bool on_get_hashes(const COMMAND_RPC_GET_HASHES_FAST::request& req, COMMAND_RPC_GET_HASHES_FAST::response& res);
     bool on_get_transactions(const COMMAND_RPC_GET_TRANSACTIONS::request& req, COMMAND_RPC_GET_TRANSACTIONS::response& res);
+    bool on_get_transactions_by_height(const COMMAND_RPC_GET_TRANSACTIONS_BY_HEIGHT::request& req, COMMAND_RPC_GET_TRANSACTIONS_BY_HEIGHT::response& res);
     bool on_is_key_image_spent(const COMMAND_RPC_IS_KEY_IMAGE_SPENT::request& req, COMMAND_RPC_IS_KEY_IMAGE_SPENT::response& res, bool request_has_rpc_origin = true);
     bool on_get_indexes(const COMMAND_RPC_GET_TX_GLOBAL_OUTPUTS_INDEXES::request& req, COMMAND_RPC_GET_TX_GLOBAL_OUTPUTS_INDEXES::response& res);
     bool on_send_raw_tx(const COMMAND_RPC_SEND_RAW_TX::request& req, COMMAND_RPC_SEND_RAW_TX::response& res);

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -94,7 +94,7 @@ namespace cryptonote
       MAP_URI_AUTO_BIN2("/getrandom_rctouts.bin", on_get_random_rct_outs, COMMAND_RPC_GET_RANDOM_RCT_OUTPUTS)
       MAP_URI_AUTO_JON2("/get_transactions", on_get_transactions, COMMAND_RPC_GET_TRANSACTIONS)
       MAP_URI_AUTO_JON2("/gettransactions", on_get_transactions, COMMAND_RPC_GET_TRANSACTIONS)
-      MAP_URI_AUTO_JON2("/gettransactions_by_height", on_get_transactions_by_height, COMMAND_RPC_GET_TRANSACTIONS_BY_HEIGHT)
+      MAP_URI_AUTO_JON2("/gettransactions_by_heights", on_get_transactions_by_height, COMMAND_RPC_GET_TRANSACTIONS_BY_HEIGHT)
       MAP_URI_AUTO_JON2("/get_alt_blocks_hashes", on_get_alt_blocks_hashes, COMMAND_RPC_GET_ALT_BLOCKS_HASHES)
       MAP_URI_AUTO_JON2("/is_key_image_spent", on_is_key_image_spent, COMMAND_RPC_IS_KEY_IMAGE_SPENT)
       MAP_URI_AUTO_JON2("/send_raw_transaction", on_send_raw_tx, COMMAND_RPC_SEND_RAW_TX)
@@ -164,7 +164,7 @@ namespace cryptonote
     bool on_get_blocks_by_height(const COMMAND_RPC_GET_BLOCKS_BY_HEIGHT::request& req, COMMAND_RPC_GET_BLOCKS_BY_HEIGHT::response& res);
     bool on_get_hashes(const COMMAND_RPC_GET_HASHES_FAST::request& req, COMMAND_RPC_GET_HASHES_FAST::response& res);
     bool on_get_transactions(const COMMAND_RPC_GET_TRANSACTIONS::request& req, COMMAND_RPC_GET_TRANSACTIONS::response& res);
-    bool on_get_transactions_by_height(const COMMAND_RPC_GET_TRANSACTIONS_BY_HEIGHT::request& req, COMMAND_RPC_GET_TRANSACTIONS_BY_HEIGHT::response& res);
+    bool on_get_transactions_by_heights(const COMMAND_RPC_GET_TRANSACTIONS_BY_HEIGHT::request& req, COMMAND_RPC_GET_TRANSACTIONS_BY_HEIGHT::response& res);
     bool on_is_key_image_spent(const COMMAND_RPC_IS_KEY_IMAGE_SPENT::request& req, COMMAND_RPC_IS_KEY_IMAGE_SPENT::response& res, bool request_has_rpc_origin = true);
     bool on_get_indexes(const COMMAND_RPC_GET_TX_GLOBAL_OUTPUTS_INDEXES::request& req, COMMAND_RPC_GET_TX_GLOBAL_OUTPUTS_INDEXES::response& res);
     bool on_send_raw_tx(const COMMAND_RPC_SEND_RAW_TX::request& req, COMMAND_RPC_SEND_RAW_TX::response& res);

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -621,6 +621,70 @@ namespace cryptonote
   };
 
   //-----------------------------------------------
+  struct COMMAND_RPC_GET_TRANSACTIONS_BY_HEIGHT
+  {
+    struct request
+    {
+      uint64_t height;
+      bool decode_as_json;
+      bool prune;
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(height)
+        KV_SERIALIZE(decode_as_json)
+        KV_SERIALIZE_OPT(prune, false)
+      END_KV_SERIALIZE_MAP()
+    };
+
+    struct entry
+    {
+      std::string tx_hash;
+      std::string as_hex;
+      std::string as_json;
+      bool in_pool;
+      bool double_spend_seen;
+      uint64_t block_height;
+      uint64_t block_timestamp;
+      std::vector<uint64_t> output_indices;
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(tx_hash)
+        KV_SERIALIZE(as_hex)
+        KV_SERIALIZE(as_json)
+        KV_SERIALIZE(in_pool)
+        KV_SERIALIZE(double_spend_seen)
+        KV_SERIALIZE(block_height)
+        KV_SERIALIZE(block_timestamp)
+        KV_SERIALIZE(output_indices)
+      END_KV_SERIALIZE_MAP()
+    };
+
+    struct response
+    {
+      // older compatibility stuff
+      std::list<std::string> txs_as_hex;  //transactions blobs as hex (old compat)
+      std::list<std::string> txs_as_json; //transactions decoded as json (old compat)
+
+      // in both old and new
+      std::list<std::string> missed_tx;   //not found transactions
+
+      // new style
+      std::vector<entry> txs;
+      std::string status;
+      bool untrusted;
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(txs_as_hex)
+        KV_SERIALIZE(txs_as_json)
+        KV_SERIALIZE(txs)
+        KV_SERIALIZE(missed_tx)
+        KV_SERIALIZE(status)
+        KV_SERIALIZE(untrusted)
+      END_KV_SERIALIZE_MAP()
+    };
+  };
+  //-----------------------------------------------
+  
   struct COMMAND_RPC_IS_KEY_IMAGE_SPENT
   {
     enum STATUS {

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -625,12 +625,12 @@ namespace cryptonote
   {
     struct request
     {
-      uint64_t height;
+      std::vector<uint64_t> heights;
       bool decode_as_json;
       bool prune;
 
       BEGIN_KV_SERIALIZE_MAP()
-        KV_SERIALIZE(height)
+        KV_SERIALIZE(heights)
         KV_SERIALIZE(decode_as_json)
         KV_SERIALIZE_OPT(prune, false)
       END_KV_SERIALIZE_MAP()


### PR DESCRIPTION
Allows you to get all transactions from a specific block height

Example usage:

`curl -X POST http://127.0.0.1:48081/gettransactions_by_height -d '{"heights":[6218,6159]}' -H 'Content-Type: application/json'`