### PR TITLE
core rpc: allow omission of binary data in get_transaction_pool

### DIFF
--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -986,6 +986,15 @@ namespace cryptonote
       return r;
 
     m_core.get_pool_transactions_and_spent_keys_info(res.transactions, res.spent_key_images, !request_has_rpc_origin || !m_restricted);
+    
+    if (req.json_only)
+    {
+      for(auto& tx: res.transactions)
+      {
+        tx.blob_size = 0;
+        tx.tx_blob = "";
+      }
+    }
     res.status = CORE_RPC_STATUS_OK;
     return true;
   }

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -1456,7 +1456,9 @@ namespace cryptonote
   {
     struct request
     {
+      bool json_only;
       BEGIN_KV_SERIALIZE_MAP()
+      KV_SERIALIZE_OPT(json_only, false)
       END_KV_SERIALIZE_MAP()
     };
 


### PR DESCRIPTION
Adds an optional json_only parameter for the get_transaction_pool rpc endpoint which will leave the tx_blob data empty