### PR TITLE
rpc: check core status before fetching supply from top block

### DIFF
--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -1062,6 +1062,7 @@ namespace cryptonote
     
     if(height == 0)
     {
+      CHECK_CORE_READY();
       height = m_core.get_current_blockchain_height() - 1;
     }
     


### PR DESCRIPTION
If get_generated_coins is called in the middle of an initial/catch-up sync then the data will be based off the latest block in the database, not the actual top block by consensus, therefore returning an incorrect number. To stop this, check the sync status and return BUSY if needed.