### PR TITLE
wallet2: std out before exiting due to out consistency failure

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -1518,6 +1518,7 @@ void wallet2::process_new_transaction(const crypto::hash &txid, const cryptonote
       MCLOG_RED(level, "global", "Consistency failure in amounts received");
       MCLOG_RED(level, "global", "Check transaction " << txid);
       MCLOG_RED(level, "global", "**********************************************************************");
+      std::cerr << "Exiting due to consistency failure in amounts received in tx " << txid << std::endl;
       exit(1);
       return;
     }


### PR DESCRIPTION
Currently the only message is logged to the log file, leaving the wallet program to exit without telling why