### PR TITLE
Allows gui wallet to build via boost 1.67, (add a cast to satisfy Boost 1.67)

### DIFF
--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -1675,7 +1675,7 @@ void WalletImpl::refreshThreadFunc()
         // if auto refresh enabled, we wait for the "m_refreshIntervalSeconds" interval.
         // if not - we wait forever
         if (m_refreshIntervalMillis > 0) {
-            boost::posix_time::milliseconds wait_for_ms(m_refreshIntervalMillis);
+            boost::posix_time::milliseconds wait_for_ms(static_cast<boost::int64_t>(m_refreshIntervalMillis));
             m_refreshCV.timed_wait(lock, wait_for_ms);
         } else {
             m_refreshCV.wait(lock);


### PR DESCRIPTION
Encountered an outright error when building the wallet GUI on OSX, which adding this solved. Strangely, this only reveals a problem when compiling the GUI. 

https://github.com/electronero/electronero/pull/45/files

many other projects have done this, it's a little obscure and lesser known problem. 