### PR TITLE
boost-1.69 build fix

### DIFF
--- a/src/cryptonote_basic/miner.cpp
+++ b/src/cryptonote_basic/miner.cpp
@@ -634,7 +634,7 @@ namespace cryptonote
         boost::tribool battery_powered(on_battery_power());
         if(!indeterminate( battery_powered ))
         {
-          on_ac_power = !battery_powered;
+          on_ac_power = !(bool)battery_powered;
         }
       }
 


### PR DESCRIPTION
Masari fails to build against the latest version of boost (1.69) on Arch Linux.